### PR TITLE
Fix radio-group to use native tabIndex property

### DIFF
--- a/packages/radio-group-base/lit-radio-group-base.js
+++ b/packages/radio-group-base/lit-radio-group-base.js
@@ -313,7 +313,7 @@ export class RadioGroupBase extends LitElement {
 
   _setFocusable(idx) {
     const items = this._radioButtons;
-    items.forEach(e => (e.tabindex = e === items[idx] ? 0 : -1));
+    items.forEach(e => (e.tabIndex = e === items[idx] ? 0 : -1));
   }
 
   _labelChanged(label) {

--- a/test/unit/radio-group.spec.js
+++ b/test/unit/radio-group.spec.js
@@ -35,9 +35,9 @@ describe('radio-group', () => {
   });
 
   it('should set focus to the first element by default', () => {
-    expect(radioList[0].tabindex).to.eq(0);
-    expect(radioList[1].tabindex).to.eq(-1);
-    expect(radioList[2].tabindex).to.eq(-1);
+    expect(radioList[0].tabIndex).to.eq(0);
+    expect(radioList[1].tabIndex).to.eq(-1);
+    expect(radioList[2].tabIndex).to.eq(-1);
   });
 
   it('should set role properly', () => {
@@ -71,16 +71,16 @@ describe('radio-group', () => {
     radioList[1].checked = true;
     await radioGroup.updateComplete;
 
-    expect(radioList[0].tabindex).to.eq(-1);
-    expect(radioList[1].tabindex).to.eq(0);
-    expect(radioList[2].tabindex).to.eq(-1);
+    expect(radioList[0].tabIndex).to.eq(-1);
+    expect(radioList[1].tabIndex).to.eq(0);
+    expect(radioList[2].tabIndex).to.eq(-1);
 
     radioList[2].checked = true;
     await radioGroup.updateComplete;
 
-    expect(radioList[0].tabindex).to.eq(-1);
-    expect(radioList[1].tabindex).to.eq(-1);
-    expect(radioList[2].tabindex).to.eq(0);
+    expect(radioList[0].tabIndex).to.eq(-1);
+    expect(radioList[1].tabIndex).to.eq(-1);
+    expect(radioList[2].tabIndex).to.eq(0);
   });
 
   it('should focus and check next/first radio button after right/down', async () => {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/web-padawan/lit-components/6)
<!-- Reviewable:end -->
