### PR TITLE
feat(details): dispatch expanded-changed notification event

### DIFF
--- a/packages/details-base/lit-details-base.js
+++ b/packages/details-base/lit-details-base.js
@@ -74,6 +74,18 @@ export class DetailsBase extends ControlStateMixin(StyledLitElement) {
     super.firstUpdated();
   }
 
+  updated(props) {
+    super.updated(props);
+
+    if (props.has('expanded')) {
+      this.dispatchEvent(
+        new CustomEvent('expanded-changed', {
+          detail: { value: this.expanded }
+        })
+      );
+    }
+  }
+
   _onToggleClick() {
     this.expanded = !this.expanded;
   }

--- a/packages/details-base/test/details.spec.js
+++ b/packages/details-base/test/details.spec.js
@@ -75,6 +75,16 @@ describe('details', () => {
     expect(style.maxHeight).to.equal('none');
   });
 
+  it('should dispatch `expanded-changed` event when `expanded changes', async () => {
+    const spy = sinon.spy();
+    details.addEventListener('expanded-changed', spy);
+    toggle.click();
+    await details.updateComplete;
+    expect(spy).to.be.calledOnce;
+    expect(spy.firstCall.args[0].detail).to.be.an('object');
+    expect(spy.firstCall.args[0].detail.value).to.equal(true);
+  });
+
   it('should update aria-expanded on toggle button when `expanded` changes', async () => {
     expect(toggle.getAttribute('aria-expanded')).to.equal('false');
     details.expanded = true;


### PR DESCRIPTION
This is needed to implement accordion component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/web-padawan/lit-components/22)
<!-- Reviewable:end -->
